### PR TITLE
Fix duplicate identifier declaration

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -1353,7 +1353,7 @@ function switchStockTab(tabId) {
         dom.manager.tabStockHistory.classList.remove('text-gray-500', 'border-transparent');
         dom.manager.tabStockHistory.classList.add('text-blue-600', 'border-blue-500');
         dom.manager.contentStockHistory.classList.remove('hidden');
-        loadStockHistoryView();
+        loadManagerStockHistoryView();
     }
 }
 
@@ -1393,7 +1393,7 @@ async function loadStockManagementView() {
 }
 
 // Carrega os dados para a view de histórico de estoque
-async function loadStockHistoryView() {
+async function loadManagerStockHistoryView() {
     console.log("loadStockHistoryView: Carregando view de histórico de estoque.");
     const { stockHistoryFilter, stockHistoryTableBody } = dom.manager;
 


### PR DESCRIPTION
Rename `loadStockHistoryView` to `loadManagerStockHistoryView` to resolve a duplicate identifier error.

---
<a href="https://cursor.com/background-agent?bcId=bc-19303984-25da-4ddd-bba7-539c751a9c0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19303984-25da-4ddd-bba7-539c751a9c0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

