### PR TITLE
Fix duplicate identifier declaration

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -1353,7 +1353,7 @@ function switchStockTab(tabId) {
         dom.manager.tabStockHistory.classList.remove('text-gray-500', 'border-transparent');
         dom.manager.tabStockHistory.classList.add('text-blue-600', 'border-blue-500');
         dom.manager.contentStockHistory.classList.remove('hidden');
-        loadStockHistoryView();
+        loadStockHistoryViewInternal();
     }
 }
 
@@ -1393,8 +1393,8 @@ async function loadStockManagementView() {
 }
 
 // Carrega os dados para a view de histórico de estoque
-async function loadStockHistoryView() {
-    console.log("loadStockHistoryView: Carregando view de histórico de estoque.");
+async function loadStockHistoryViewInternal() {
+    console.log("loadStockHistoryViewInternal: Carregando view de histórico de estoque.");
     const { stockHistoryFilter, stockHistoryTableBody } = dom.manager;
 
     if (stockLogs.length > 0) {


### PR DESCRIPTION
Rename `loadStockHistoryView` to `loadStockHistoryViewInternal` to fix a duplicate identifier error.

The `SyntaxError: Identifier 'loadStockHistoryView' has already been declared` was occurring, likely due to the function being re-declared during live reload or in a bundled script.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ab23a95-41b5-4f80-b01b-b2ae23d0a90f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ab23a95-41b5-4f80-b01b-b2ae23d0a90f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

